### PR TITLE
feat(demo): allow full-screen demos without header

### DIFF
--- a/components.js
+++ b/components.js
@@ -3,9 +3,21 @@ import demo1 from './src/components/atoms/icon/demo.js';
 import demo2 from './src/components/atoms/touchable/demo.js';
 import demo3 from './src/components/molecules/component-row/demo.js';
 import demo4 from './src/components/molecules/demo-header/demo.js';
-import demo5 from './src/components/organisms/demo-tile/demo.js';
-import demo6 from './src/components/scenes/component-list/demo.js';
-import demo7 from './src/components/scenes/demo/demo.js';
-import demo8 from './src/components/scenes/full-screen-demo/demo.js';
+import demo5 from './src/components/molecules/floating-button/demo.js';
+import demo6 from './src/components/organisms/demo-tile/demo.js';
+import demo7 from './src/components/scenes/component-list/demo.js';
+import demo8 from './src/components/scenes/demo/demo.js';
+import demo9 from './src/components/scenes/full-screen-demo/demo.js';
 
-export default [demo0, demo1, demo2, demo3, demo4, demo5, demo6, demo7, demo8];
+export default [
+    demo0,
+    demo1,
+    demo2,
+    demo3,
+    demo4,
+    demo5,
+    demo6,
+    demo7,
+    demo8,
+    demo9,
+];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rnuix",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"main": "./src/index.js",
 	"bin": "./bin/rnuix",
 	"scripts": {

--- a/src/components/atoms/demo-renderer/index.js
+++ b/src/components/atoms/demo-renderer/index.js
@@ -16,27 +16,17 @@ export default function DemoRenderer(
     }: DemoRendererProps,
 ) {
     return (
-        <ScrollView
-            style={[
-                styles.demo,
-                isFullScreen ? styles.fullScreen : styles.tile,
-            ]}
-        >
+        <ScrollView style={isFullScreen ? styles.fullScreen : styles.tile}>
             {render()}
         </ScrollView>
     );
 }
 
 const styles = StyleSheet.create({
-    demo: {
-        backgroundColor: colors.white,
-    },
     fullScreen: {
         flex: 1,
     },
     tile: {
-        borderBottomLeftRadius: 3,
-        borderBottomRightRadius: 3,
         padding: 10,
     },
 });

--- a/src/components/atoms/demo-renderer/index.js
+++ b/src/components/atoms/demo-renderer/index.js
@@ -16,7 +16,10 @@ export default function DemoRenderer(
     }: DemoRendererProps,
 ) {
     return (
-        <ScrollView style={isFullScreen ? styles.fullScreen : styles.tile}>
+        <ScrollView
+            style={isFullScreen && styles.fullScreen}
+            contentContainerStyle={!isFullScreen && styles.tile}
+        >
             {render()}
         </ScrollView>
     );

--- a/src/components/atoms/icon/index.js
+++ b/src/components/atoms/icon/index.js
@@ -4,10 +4,11 @@ import { Image } from 'react-native';
 
 export type IconProps = {
     name: string,
+    tintColor?: string,
 };
 
-export default function Icon({ name }: IconProps) {
-    return <Image source={icons[name]} />;
+export default function Icon({ name, tintColor }: IconProps) {
+    return <Image source={icons[name]} style={{ tintColor }} />;
 }
 
 const icons = {

--- a/src/components/atoms/touchable/demo.js
+++ b/src/components/atoms/touchable/demo.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 
+import { colors } from '../../../themes';
 import Touchable from './';
 
 export default {
@@ -25,20 +26,9 @@ export default {
                     onPress={() => {}}
                     activeOpacity={0.5}
                     rippleColor="#fff6"
-                    style={{
-                        backgroundColor: '#78c',
-                        borderRadius: 3,
-                        margin: 10,
-                        padding: 10,
-                    }}
+                    style={styles.customWrapper}
                 >
-                    <Text
-                        style={{
-                            color: '#fff',
-                            fontWeight: 'bold',
-                            textAlign: 'center',
-                        }}
-                    >
+                    <Text style={styles.customText}>
                         Touch me!
                     </Text>
                 </Touchable>
@@ -50,20 +40,9 @@ export default {
                 <Touchable
                     disabled
                     onPress={() => {}}
-                    style={{
-                        backgroundColor: '#78c',
-                        borderRadius: 3,
-                        margin: 10,
-                        padding: 10,
-                    }}
+                    style={styles.customWrapper}
                 >
-                    <Text
-                        style={{
-                            color: '#fff',
-                            fontWeight: 'bold',
-                            textAlign: 'center',
-                        }}
-                    >
+                    <Text style={styles.customText}>
                         Can't touch this
                     </Text>
                 </Touchable>
@@ -71,3 +50,17 @@ export default {
         },
     ],
 };
+
+const styles = StyleSheet.create({
+    customWrapper: {
+        backgroundColor: colors.blue,
+        borderRadius: 3,
+        margin: 10,
+        padding: 10,
+    },
+    customText: {
+        color: colors.white,
+        fontWeight: 'bold',
+        textAlign: 'center',
+    },
+});

--- a/src/components/atoms/touchable/index.js
+++ b/src/components/atoms/touchable/index.js
@@ -35,7 +35,7 @@ function StyledTouchableNativeFeedback(
     );
 }
 
-type TouchableProps = typeof TouchableOpacity & StyledTouchableNativeFeedbackProps;
+export type TouchableProps = typeof TouchableOpacity & StyledTouchableNativeFeedbackProps;
 
 export default function Touchable(
     {

--- a/src/components/atoms/touchable/index.js
+++ b/src/components/atoms/touchable/index.js
@@ -8,7 +8,7 @@ import {
     View,
 } from 'react-native';
 
-type StyledTouchableNativeFeedbackProps = typeof TouchableNativeFeedback & {
+type StyledTouchableNativeFeedbackProps = TouchableNativeFeedback.props & {
     borderless?: boolean,
     rippleColor?: string,
     style?: StyleSheet.Style,
@@ -35,7 +35,7 @@ function StyledTouchableNativeFeedback(
     );
 }
 
-export type TouchableProps = typeof TouchableOpacity & StyledTouchableNativeFeedbackProps;
+export type TouchableProps = TouchableOpacity.props & StyledTouchableNativeFeedbackProps;
 
 export default function Touchable(
     {

--- a/src/components/molecules/demo-header/index.js
+++ b/src/components/molecules/demo-header/index.js
@@ -8,15 +8,12 @@ import Touchable from '../../atoms/touchable';
 
 export type DemoHeaderProps = {
     onEnterFullScreen?: () => void,
-    onExitFullScreen?: () => void,
     title: string,
 };
 
 export default function DemoHeader(
     {
-        isFullScreen,
         onEnterFullScreen,
-        onExitFullScreen,
         title,
     }: DemoHeaderProps,
 ) {

--- a/src/components/molecules/floating-button/demo.js
+++ b/src/components/molecules/floating-button/demo.js
@@ -2,7 +2,6 @@
 import React from 'react';
 
 import { colors } from '../../../themes';
-import Icon from '../../atoms/icon';
 import FloatingButton from './';
 
 export default {

--- a/src/components/molecules/floating-button/demo.js
+++ b/src/components/molecules/floating-button/demo.js
@@ -1,0 +1,36 @@
+// @flow
+import React from 'react';
+
+import { colors } from '../../../themes';
+import Icon from '../../atoms/icon';
+import FloatingButton from './';
+
+export default {
+    displayName: 'FloatingButton',
+    description: 'Renders a rounded button appropriate for primary screen actions.',
+    demos: [
+        {
+            title: 'Default',
+            render: () => <FloatingButton name="close" />,
+        },
+        {
+            title: 'Custom style',
+            render: () => (
+                <FloatingButton
+                    name="fullscreen"
+                    style={{ backgroundColor: colors.blue }}
+                />
+            ),
+        },
+        {
+            title: 'Custom style and tintColor',
+            render: () => (
+                <FloatingButton
+                    name="fullscreen"
+                    tintColor={colors.black}
+                    style={{ backgroundColor: colors.silverLight }}
+                />
+            ),
+        },
+    ],
+};

--- a/src/components/molecules/floating-button/index.js
+++ b/src/components/molecules/floating-button/index.js
@@ -8,7 +8,7 @@ import type { IconProps } from '../../atoms/icon';
 
 export type FloatingButtonProps = typeof TouchableOpacity & IconProps;
 
-export default function ExitButton(
+export default function FloatingButton(
     { style, name, tintColor = colors.white, ...props }: FloatingButtonProps,
 ) {
     return (

--- a/src/components/molecules/floating-button/index.js
+++ b/src/components/molecules/floating-button/index.js
@@ -1,0 +1,35 @@
+// @flow
+import React from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+
+import { colors, mixins } from '../../../themes';
+import Icon from '../../atoms/icon';
+import type { IconProps } from '../../atoms/icon';
+
+export type FloatingButtonProps = typeof TouchableOpacity & IconProps;
+
+export default function ExitButton(
+    { style, name, tintColor = colors.white, ...props }: FloatingButtonProps,
+) {
+    return (
+        <TouchableOpacity
+            activeOpacity={0.7}
+            style={[styles.container, style]}
+            {...props}
+        >
+            <Icon name={name} tintColor={tintColor} />
+        </TouchableOpacity>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 56,
+        height: 56,
+        borderRadius: 28,
+        backgroundColor: colors.red,
+        ...mixins.elevation(6),
+    },
+});

--- a/src/components/molecules/floating-button/index.js
+++ b/src/components/molecules/floating-button/index.js
@@ -3,10 +3,9 @@ import React from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 
 import { colors, mixins } from '../../../themes';
-import Icon from '../../atoms/icon';
-import type { IconProps } from '../../atoms/icon';
+import Icon, { type IconProps } from '../../atoms/icon';
 
-export type FloatingButtonProps = typeof TouchableOpacity & IconProps;
+export type FloatingButtonProps = TouchableOpacity.props & IconProps;
 
 export default function FloatingButton(
     { style, name, tintColor = colors.white, ...props }: FloatingButtonProps,

--- a/src/components/organisms/demo-tile/demo.js
+++ b/src/components/organisms/demo-tile/demo.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 
+import { colors, metrics } from '../../../themes';
 import DemoTile from './';
 
 export default {
@@ -24,6 +25,30 @@ export default {
                     render={() => <Text>Content</Text>}
                 />
             ),
+        },
+        {
+            title: 'Full screen mode without header',
+            render: () => (
+                <DemoTile
+                    title="title"
+                    isFullScreen
+                    render={() => (
+                        <View
+                            style={{
+                                width: metrics.window.width,
+                                height: metrics.window.height,
+                                borderColor: colors.gray,
+                                borderStyle: 'solid',
+                                borderWidth: 10,
+                                padding: 10,
+                            }}
+                        >
+                            <Text>Large content</Text>
+                        </View>
+                    )}
+                />
+            ),
+            hideHeader: true,
         },
     ],
 };

--- a/src/components/organisms/demo-tile/index.js
+++ b/src/components/organisms/demo-tile/index.js
@@ -2,13 +2,16 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import { colors } from '../../../themes';
-import DemoHeader from '../../molecules/demo-header';
+import { colors, mixins } from '../../../themes';
 import DemoRenderer from '../../atoms/demo-renderer';
-import type { DemoHeaderProps } from '../../molecules/demo-header';
+import DemoHeader from '../../molecules/demo-header';
+import FloatingButton from '../../molecules/floating-button';
 import type { DemoRendererProps } from '../../atoms/demo-renderer';
+import type { DemoHeaderProps } from '../../molecules/demo-header';
 
 export type DemoTileProps = DemoHeaderProps & DemoRendererProps & {
+    onExitFullScreen?: () => void,
+    hideHeader?: boolean,
     style?: StyleSheet.Style,
 };
 
@@ -16,6 +19,7 @@ export default function DemoTile(
     {
         render,
         isFullScreen = false,
+        hideHeader = false,
         onEnterFullScreen,
         onExitFullScreen,
         style,
@@ -25,10 +29,15 @@ export default function DemoTile(
     return (
         <View style={[isFullScreen ? null : styles.container, style]}>
             {isFullScreen
-                ? null
+                ? hideHeader
+                      ? <FloatingButton
+                            onPress={onExitFullScreen}
+                            style={styles.exitButton}
+                            name="close"
+                        />
+                      : null
                 : <DemoHeader
                       onEnterFullScreen={onEnterFullScreen}
-                      onExitFullScreen={onExitFullScreen}
                       title={title}
                   />}
             <DemoRenderer render={render} isFullScreen={isFullScreen} />
@@ -38,8 +47,13 @@ export default function DemoTile(
 
 const styles = StyleSheet.create({
     container: {
-        borderColor: colors.silverDark,
         borderRadius: 3,
-        borderWidth: 0.5,
+        ...mixins.elevation(2),
+    },
+    exitButton: {
+        position: 'absolute',
+        bottom: 20,
+        left: 20,
+        zIndex: 1,
     },
 });

--- a/src/components/organisms/demo-tile/index.js
+++ b/src/components/organisms/demo-tile/index.js
@@ -3,11 +3,11 @@ import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { colors, mixins } from '../../../themes';
-import DemoRenderer from '../../atoms/demo-renderer';
-import DemoHeader from '../../molecules/demo-header';
+import DemoRenderer, {
+    type DemoRendererProps,
+} from '../../atoms/demo-renderer';
+import DemoHeader, { type DemoHeaderProps } from '../../molecules/demo-header';
 import FloatingButton from '../../molecules/floating-button';
-import type { DemoRendererProps } from '../../atoms/demo-renderer';
-import type { DemoHeaderProps } from '../../molecules/demo-header';
 
 export type DemoTileProps = DemoHeaderProps & DemoRendererProps & {
     onExitFullScreen?: () => void,

--- a/src/components/organisms/demo-tile/index.js
+++ b/src/components/organisms/demo-tile/index.js
@@ -47,6 +47,7 @@ export default function DemoTile(
 
 const styles = StyleSheet.create({
     container: {
+        backgroundColor: colors.white,
         borderRadius: 3,
         ...mixins.elevation(2),
     },

--- a/src/components/scenes/component-list/index.js
+++ b/src/components/scenes/component-list/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { ListView, StyleSheet } from 'react-native';
+import { ListView, Platform, StyleSheet } from 'react-native';
 
 import { colors } from '../../../themes';
 import ComponentRow from '../../molecules/component-row';
@@ -31,7 +31,12 @@ export default class ComponentList extends Component {
                 borderless
                 rippleColor="rgba(0, 0, 0, 0.32)"
             >
-                <Icon name="close" />
+                <Icon
+                    name="close"
+                    tintColor={
+                        Platform.OS === 'ios' ? colors.blue : colors.black
+                    }
+                />
             </Touchable>,
     });
     props: Props;

--- a/src/components/scenes/demo/index.js
+++ b/src/components/scenes/demo/index.js
@@ -52,8 +52,6 @@ export default class Demo extends Component {
             render={props.render}
             onEnterFullScreen={() =>
                 this.props.navigation.navigate('fullScreen', props)}
-            onExitFullScreen={() =>
-                this.props.navigation.navigate('demo', props)}
         />
     );
 

--- a/src/components/scenes/demo/index.js
+++ b/src/components/scenes/demo/index.js
@@ -58,7 +58,7 @@ export default class Demo extends Component {
     render() {
         return (
             <ListView
-                style={styles.scene}
+                contentContainerStyle={styles.content}
                 dataSource={this.state.dataSource}
                 enableEmptySections={true}
                 renderRow={this.renderRow}
@@ -68,8 +68,9 @@ export default class Demo extends Component {
 }
 
 const styles = StyleSheet.create({
-    scene: {
+    content: {
         padding: 6,
+        paddingBottom: 0,
     },
     demo: {
         marginBottom: 6,

--- a/src/components/scenes/full-screen-demo/demo.js
+++ b/src/components/scenes/full-screen-demo/demo.js
@@ -13,6 +13,7 @@ export default {
             render: () => (
                 <FullScreenDemo
                     navigation={{
+                        goBack: () => {},
                         state: {
                             params: {
                                 title: 'title',

--- a/src/components/scenes/full-screen-demo/index.js
+++ b/src/components/scenes/full-screen-demo/index.js
@@ -1,34 +1,42 @@
 // @flow
 import React from 'react';
-import { StyleSheet, Text } from 'react-native';
+import { StyleSheet } from 'react-native';
+
 import DemoTile from '../../organisms/demo-tile';
 import type { Component } from '../../../../type-definitions';
 
 export type Props = {
     navigation: {
+        goBack: () => void,
         state: {
             params: Component,
         },
     },
 };
 
-export default function FullScreenDemo(
-    { navigation: { state: { params: props } } }: Props,
-) {
+export default function FullScreenDemo({ navigation }: Props) {
+    const props = navigation.state.params;
     return (
         <DemoTile
             style={styles.demo}
             title={props.title}
             render={props.render}
             isFullScreen
+            hideHeader={props.hideHeader}
+            onExitFullScreen={() => navigation.goBack()}
         />
     );
 }
 
-FullScreenDemo.navigationOptions = ({ navigation }) => ({
-    title: navigation.state.params.title,
-    headerBackTitle: null,
-});
+FullScreenDemo.navigationOptions = ({ navigation: { state: { params } } }) => {
+    if (params.hideHeader) {
+        return { header: null };
+    }
+    return {
+        title: params.title,
+        headerBackTitle: null,
+    };
+};
 
 const styles = StyleSheet.create({
     demo: {

--- a/src/themes/colors.js
+++ b/src/themes/colors.js
@@ -1,8 +1,8 @@
-export default {
-    black: '#000',
-    gray: '#969699',
-    silverDark: '#d9d9dd',
-    silver: '#eaeaee',
-    silverLight: '#f2f2f5',
-    white: '#fff',
-};
+export const black = '#000';
+export const gray = '#969699';
+export const silverDark = '#d9d9dd';
+export const silver = '#eaeaee';
+export const silverLight = '#f2f2f5';
+export const white = '#fff';
+export const blue = '#007aff';
+export const red = '#ff3a2d';

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -1,1 +1,5 @@
-export { default as colors } from './colors';
+import * as colors from './colors';
+import * as metrics from './metrics';
+import * as mixins from './mixins';
+
+export { colors, metrics, mixins };

--- a/src/themes/metrics.js
+++ b/src/themes/metrics.js
@@ -1,0 +1,4 @@
+// @flow
+import { Dimensions } from 'react-native';
+
+export const window = Dimensions.get('window');

--- a/src/themes/mixins.js
+++ b/src/themes/mixins.js
@@ -1,0 +1,17 @@
+import { Platform } from 'react-native';
+
+// Calculate elevation shadow with values from here:
+// https://github.com/alekhurst/react-native-elevated-view/blob/7fee91a2c879e88f9359582268c6d8ebee5b99a3/index.js#L32
+export function elevation(elevation) {
+    if (Platform.OS === 'android') {
+        return { elevation };
+    }
+
+    return {
+        shadowOpacity: 0.0015 * elevation + 0.18,
+        shadowRadius: 0.54 * elevation,
+        shadowOffset: {
+            height: 0.6 * elevation,
+        },
+    };
+}

--- a/type-definitions.js
+++ b/type-definitions.js
@@ -2,4 +2,5 @@ export type Component = {
     displayName: string,
     description: string,
     demos: { title: string, render: () => React.Element<*> }[],
+    hideHeader?: boolean,
 };


### PR DESCRIPTION
Allow adding a `hideHeader` flag to demos so full-screen view is
rendered without a header. In this case, a floating button is added on
the bottom left to navigate back.