### PR TITLE
feat(demo): allow custom demo header

### DIFF
--- a/src/components/organisms/demo-tile/demo.js
+++ b/src/components/organisms/demo-tile/demo.js
@@ -5,6 +5,10 @@ import { Text, View } from 'react-native';
 import { colors, metrics } from '../../../themes';
 import DemoTile from './';
 
+import { ExitFullScreenFAB } from '../../../';
+
+import type { HeaderProps } from 'react-navigation';
+
 export default {
     displayName: 'DemoTile',
     description: 'Renders a demo.',
@@ -48,11 +52,12 @@ export default {
                     )}
                 />
             ),
-            hideHeader: true,
-            exitButtonStyle: {
-                left: null,
-                right: 20,
-            },
+            renderHeader: (props: HeaderProps) => (
+                <ExitFullScreenFAB
+                    style={{ left: null, right: 20 }}
+                    {...props}
+                />
+            ),
         },
     ],
 };

--- a/src/components/organisms/demo-tile/index.js
+++ b/src/components/organisms/demo-tile/index.js
@@ -7,13 +7,10 @@ import DemoRenderer, {
     type DemoRendererProps,
 } from '../../atoms/demo-renderer';
 import DemoHeader, { type DemoHeaderProps } from '../../molecules/demo-header';
-import FloatingButton from '../../molecules/floating-button';
 
 export type DemoTileProps = DemoHeaderProps & DemoRendererProps & {
     onExitFullScreen?: () => void,
-    hideHeader?: boolean,
     style?: StyleSheet.Style,
-    exitButtonStyle?: StyleSheet.Style,
 };
 
 export default function DemoTile(
@@ -22,22 +19,14 @@ export default function DemoTile(
         isFullScreen = false,
         hideHeader = false,
         onEnterFullScreen,
-        onExitFullScreen,
         style,
         title,
-        exitButtonStyle,
     }: DemoTileProps,
 ) {
     return (
         <View style={[isFullScreen ? null : styles.container, style]}>
             {isFullScreen
-                ? hideHeader
-                      ? <FloatingButton
-                            onPress={onExitFullScreen}
-                            style={[styles.exitButton, exitButtonStyle]}
-                            name="arrow_back"
-                        />
-                      : null
+                ? null
                 : <DemoHeader
                       onEnterFullScreen={onEnterFullScreen}
                       title={title}
@@ -52,11 +41,5 @@ const styles = StyleSheet.create({
         backgroundColor: colors.white,
         borderRadius: 3,
         ...mixins.elevation(2),
-    },
-    exitButton: {
-        position: 'absolute',
-        bottom: 20,
-        left: 20,
-        zIndex: 1,
     },
 });

--- a/src/components/organisms/exit-full-screen-fab/index.js
+++ b/src/components/organisms/exit-full-screen-fab/index.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import FloatingButton from '../../molecules/floating-button';
+
+import type { HeaderProps } from 'react-navigation';
+
+export default function ExitFullScreenFAB({ navigation, style }: HeaderProps) {
+    return (
+        <FloatingButton
+            onPress={() => navigation.goBack(null)}
+            style={[styles.exitButton, style]}
+            name="arrow_back"
+        />
+    );
+}
+
+const styles = StyleSheet.create({
+    exitButton: {
+        position: 'absolute',
+        bottom: 20,
+        left: 20,
+        zIndex: 1,
+    },
+});

--- a/src/components/organisms/exit-full-screen-fab/index.js
+++ b/src/components/organisms/exit-full-screen-fab/index.js
@@ -6,7 +6,11 @@ import FloatingButton from '../../molecules/floating-button';
 
 import type { HeaderProps } from 'react-navigation';
 
-export default function ExitFullScreenFAB({ navigation, style }: HeaderProps) {
+export type ExitFullScreenFABProps = HeaderProps;
+
+export default function ExitFullScreenFAB(
+    { navigation, style }: ExitFullScreenFABProps,
+) {
     return (
         <FloatingButton
             onPress={() => navigation.goBack(null)}

--- a/src/components/scenes/full-screen-demo/demo.js
+++ b/src/components/scenes/full-screen-demo/demo.js
@@ -13,7 +13,6 @@ export default {
             render: () => (
                 <FullScreenDemo
                     navigation={{
-                        goBack: () => {},
                         state: {
                             params: {
                                 title: 'title',

--- a/src/components/scenes/full-screen-demo/index.js
+++ b/src/components/scenes/full-screen-demo/index.js
@@ -2,12 +2,12 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 
+import FloatingButton from '../../molecules/floating-button';
 import DemoTile from '../../organisms/demo-tile';
 import type { Component } from '../../../../type-definitions';
 
 export type Props = {
     navigation: {
-        goBack: () => void,
         state: {
             params: Component,
         },
@@ -22,16 +22,21 @@ export default function FullScreenDemo({ navigation }: Props) {
             title={props.title}
             render={props.render}
             isFullScreen
-            hideHeader={props.hideHeader}
-            exitButtonStyle={props.exitButtonStyle}
-            onExitFullScreen={() => navigation.goBack()}
         />
     );
 }
 
-FullScreenDemo.navigationOptions = ({ navigation: { state: { params } } }) => {
-    if (params.hideHeader) {
-        return { header: null };
+FullScreenDemo.navigationOptions = props => {
+    const { params } = props.navigation.state;
+    if (params.renderHeader) {
+        return {
+            header: params.renderHeader(props),
+        };
+    }
+    if (params.renderHeader === null) {
+        return {
+            header: null,
+        };
     }
     return {
         title: params.title,

--- a/src/components/scenes/full-screen-demo/index.js
+++ b/src/components/scenes/full-screen-demo/index.js
@@ -28,7 +28,7 @@ export default function FullScreenDemo({ navigation }: Props) {
 
 FullScreenDemo.navigationOptions = props => {
     const { params } = props.navigation.state;
-    if (params.renderHeader) {
+    if (typeof params.renderHeader === 'function') {
         return {
             header: params.renderHeader(props),
         };

--- a/src/index.js
+++ b/src/index.js
@@ -19,5 +19,9 @@ export const App = StackNavigator(
     },
 );
 
+export {
+    default as ExitFullScreenFAB,
+} from './components/organisms/exit-full-screen-fab';
+
 export default (components: ComponentT[] = []) =>
     () => <App screenProps={{ components }} />;

--- a/type-definitions.js
+++ b/type-definitions.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import type { HeaderProps } from 'react-navigation';
 
 export type Component = {
     displayName: string,
     description: string,
     demos: { title: string, render: () => React.Element<*> }[],
-    renderHeader?: ?() => React.Element<*>,
+    renderHeader?: ?(props: HeaderProps) => React.Element<*>,
 };

--- a/type-definitions.js
+++ b/type-definitions.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
 
 export type Component = {
     displayName: string,
     description: string,
     demos: { title: string, render: () => React.Element<*> }[],
-    hideHeader?: boolean,
-    exitButtonStyle?: StyleSheet.Style,
+    renderHeader?: ?() => React.Element<*>,
 };


### PR DESCRIPTION
Replace `hideHeader` and `exitButtonStyle` by a `renderHeader` option.
It takes a function returning a component. A floating action button is
provided for convenience.