### PR TITLE
feat(demo): pass navigation to demo render function

### DIFF
--- a/src/components/atoms/demo-renderer/demo.js
+++ b/src/components/atoms/demo-renderer/demo.js
@@ -10,7 +10,11 @@ export default {
     demos: [
         {
             title: 'Normal mode',
-            render: () => <DemoRenderer render={() => <Text>Content</Text>} />,
+            render: () =>
+                <DemoRenderer
+                    render={() => <Text>Content</Text>}
+                    navigation={{}}
+                />,
         },
         {
             title: 'Full screen mode',
@@ -18,6 +22,7 @@ export default {
                 <DemoRenderer
                     isFullScreen
                     render={() => <Text>Content</Text>}
+                    navigation={{}}
                 />,
         },
     ],

--- a/src/components/atoms/demo-renderer/index.js
+++ b/src/components/atoms/demo-renderer/index.js
@@ -7,18 +7,20 @@ import { colors } from '../../../themes';
 export type DemoRendererProps = {
     isFullScreen?: boolean,
     render: () => React.Element<*>,
+    navigation: Object,
 };
 
 export default function DemoRenderer({
     isFullScreen,
     render,
+    navigation,
 }: DemoRendererProps) {
     return (
         <ScrollView
             style={isFullScreen && styles.fullScreen}
             contentContainerStyle={!isFullScreen && styles.tile}
         >
-            {render()}
+            {render({ navigation })}
         </ScrollView>
     );
 }

--- a/src/components/organisms/demo-tile/demo.js
+++ b/src/components/organisms/demo-tile/demo.js
@@ -16,7 +16,11 @@ export default {
         {
             title: 'Normal mode',
             render: () =>
-                <DemoTile title="title" render={() => <Text>Content</Text>} />,
+                <DemoTile
+                    title="title"
+                    render={() => <Text>Content</Text>}
+                    navigation={{}}
+                />,
         },
         {
             title: 'Full screen mode',
@@ -26,6 +30,7 @@ export default {
                     isFullScreen
                     style={{ height: 50 }}
                     render={() => <Text>Content</Text>}
+                    navigation={{}}
                 />,
         },
         {
@@ -47,6 +52,7 @@ export default {
                         >
                             <Text>Large content</Text>
                         </View>}
+                    navigation={{}}
                 />,
             renderHeader: (props: HeaderProps) =>
                 <ExitFullScreenFAB

--- a/src/components/organisms/demo-tile/index.js
+++ b/src/components/organisms/demo-tile/index.js
@@ -19,6 +19,7 @@ export default function DemoTile({
     onEnterFullScreen,
     style,
     title,
+    navigation,
 }: DemoTileProps) {
     return (
         <View style={[isFullScreen ? null : styles.container, style]}>
@@ -28,7 +29,11 @@ export default function DemoTile({
                       onEnterFullScreen={onEnterFullScreen}
                       title={title}
                   />}
-            <DemoRenderer render={render} isFullScreen={isFullScreen} />
+            <DemoRenderer
+                render={render}
+                isFullScreen={isFullScreen}
+                navigation={navigation}
+            />
         </View>
     );
 }

--- a/src/components/scenes/demo/index.js
+++ b/src/components/scenes/demo/index.js
@@ -50,6 +50,7 @@ export default class Demo extends Component {
             style={styles.demo}
             title={props.title}
             render={props.render}
+            navigation={this.props.navigation}
             onEnterFullScreen={() =>
                 this.props.navigation.navigate('fullScreen', props)}
         />;

--- a/src/components/scenes/full-screen-demo/index.js
+++ b/src/components/scenes/full-screen-demo/index.js
@@ -21,6 +21,7 @@ export default function FullScreenDemo({ navigation }: Props) {
             style={styles.demo}
             title={props.title}
             render={props.render}
+            navigation={navigation}
             isFullScreen
         />
     );


### PR DESCRIPTION
So a demo can use things like navigation.goBack() which is useful for
full-screen demos without header or back button.